### PR TITLE
fix: use correct id sequence (dialer even/listener odd)

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ necessarily send the first packet, this distinction is just made to make the all
 
 ### Opening a new stream
 
-To open a new stream, first allocate a new unique stream ID; the session initiator allocates odd IDs and the session receiver allocates even IDs. Then, send a message with the flag set to `NewStream`, the ID set to the newly
+To open a new stream, first allocate a new unique stream ID; the session initiator allocates even IDs and the session receiver allocates odd IDs. Then, send a message with the flag set to `NewStream`, the ID set to the newly
 allocated stream ID, and the data of the message set to the name of the stream.
 
 Stream names are purely for interfaces and are not otherwise considered by the protocol. An empty string may also be used for the stream name, and they may also be repeated (using the same stream name for every stream is valid). Reusing

--- a/README.md
+++ b/README.md
@@ -52,13 +52,13 @@ necessarily send the first packet, this distinction is just made to make the all
 
 ### Opening a new stream
 
-To open a new stream, first allocate a new unique stream ID; the session initiator allocates even IDs and the session receiver allocates odd IDs. Then, send a message with the flag set to `NewStream`, the ID set to the newly
+To open a new stream, first allocate a new unique stream ID. Then, send a message with the flag set to `NewStream`, the ID set to the newly
 allocated stream ID, and the data of the message set to the name of the stream.
 
 Stream names are purely for interfaces and are not otherwise considered by the protocol. An empty string may also be used for the stream name, and they may also be repeated (using the same stream name for every stream is valid). Reusing
 a stream ID after closing a stream may result in undefined behaviour.
 
-The party that opens a stream is called the stream initiator. This is used for numbering the streams.
+The party that opens a stream is called the stream initiator. This is used for numbering the streams as well as identifying whether the message comes from a channel opened locally or remotely. Thus, the stream initiator always uses even flags and stream receivers uses odd flags.
 
 ### Writing to a stream
 

--- a/README.md
+++ b/README.md
@@ -52,13 +52,11 @@ necessarily send the first packet, this distinction is just made to make the all
 
 ### Opening a new stream
 
-To open a new stream, first allocate a new unique stream ID. Then, send a message with the flag set to `NewStream`, the ID set to the newly
-allocated stream ID, and the data of the message set to the name of the stream.
+To open a new stream, first allocate a new stream ID. Then, send a message with the flag set to `NewStream`, the ID set to the newly allocated stream ID, and the data of the message set to the name of the stream. 
 
-Stream names are purely for interfaces and are not otherwise considered by the protocol. An empty string may also be used for the stream name, and they may also be repeated (using the same stream name for every stream is valid). Reusing
-a stream ID after closing a stream may result in undefined behaviour.
+Stream names are purely for interfaces and are not otherwise considered by the protocol. An empty string may also be used for the stream name, and they may also be repeated (using the same stream name for every stream is valid). Reusing a stream ID after closing a stream may result in undefined behaviour.
 
-The party that opens a stream is called the stream initiator. This is used for numbering the streams as well as identifying whether the message comes from a channel opened locally or remotely. Thus, the stream initiator always uses even flags and stream receivers uses odd flags.
+The party that opens a stream is called the stream initiator. This is used to identify whether the message comes from a channel opened locally or remotely. Thus, the stream initiator always uses even flags and stream receivers uses odd flags.
 
 ### Writing to a stream
 


### PR DESCRIPTION
There is an inconsistency in the spec. It says odd IDs are used for initiators and even ids for receiver. This is reverced from the current js implementation - https://github.com/libp2p/js-libp2p-mplex/blob/master/src/internals/index.js#L83-L91.